### PR TITLE
fix seurat reference if subset after harmony

### DIFF
--- a/vignettes/utils_seurat.R
+++ b/vignettes/utils_seurat.R
@@ -10,7 +10,7 @@ buildReferenceFromSeurat <- function(
     res$Z_orig <- t(obj@reductions$pca@cell.embeddings)
     message('Saved embeddings')
     
-    res$R <- t(obj@reductions$harmony@misc$R)
+    res$R <- t(obj@reductions$harmony@misc$R[colnames(obj),]) # seurat does not subset misc slot
     message('Saved soft cluster assignments')
     
     if (assay == 'RNA') {


### PR DESCRIPTION
Subsetting Seurat object after running Harmony results in dimension mismatch in obj@reductions$harmony@misc$R because the subset function as implemented in Seurat does not modify the misc slot. This fixes the mismatch by subsetting to the appropriate rows before matmul.